### PR TITLE
chore(ci): update Trunk setup action refs

### DIFF
--- a/.trunk/setup-ci/action.yaml
+++ b/.trunk/setup-ci/action.yaml
@@ -4,7 +4,7 @@ description: Set up dependencies for Trunk Code Quality
 runs:
     using: composite
     steps:
-        - uses: pnpm/action-setup@v4 # zizmor: ignore[unpinned-uses]
+        - uses: pnpm/action-setup@v6 # zizmor: ignore[unpinned-uses]
           with:
               version: 10
 


### PR DESCRIPTION
## Summary

Updates the Trunk setup composite action refs used by CI while preserving the existing Node 24 runtime and package-manager versions.

## Changes

🔄 CI/CD
- pnpm/action-setup v4 -> v6
- Leaves `node-version: 24` unchanged
- Leaves existing PNPM version values unchanged

## Testing

- Verified the diff is limited to `.trunk/setup-ci/action.yaml`

## Commits

- [`bf1e5ed`](https://github.com/humanspeak/svelte-purify/commit/bf1e5ed12f849d93ac5d63d7833412157715c3d8) chore(ci): update Trunk setup action refs
