### PR TITLE
ci(npm-publish): run publish job on github-hosted runner (fix provenance E422)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -312,7 +312,10 @@ jobs:
     publish-github-packages:
         needs: [check-if-merged, build, playwright-tests, coverage-report]
         if: needs.check-if-merged.outputs.should_run == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        # npm provenance (--provenance) requires a GitHub-hosted runner; a
+        # self-hosted blacksmith runner is rejected with E422. Every other repo
+        # in the fleet runs this job on ubuntu-latest.
+        runs-on: ubuntu-latest
         environment: production
         permissions:
             contents: write


### PR DESCRIPTION
## Problem

After the Node 20 fix unblocked the build, the publish step still failed ([run 28197409859](https://github.com/humanspeak/svelte-purify/actions/runs/28197409859)):

```
npm error code E422
npm error 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Unsupported GitHub Actions runner environment: "self-hosted".
Only "github-hosted" runners are supported when publishing with provenance.
```

OIDC trusted publishing worked (the provenance statement was signed and logged) — npm rejected it only because the job ran on a **self-hosted blacksmith runner**.

## Root cause

`publish-github-packages` was the only publish job in the fleet on `blacksmith-2vcpu-ubuntu-2404`; every other repo uses `ubuntu-latest`. `pnpm publish --provenance` requires a GitHub-hosted runner.

## Fix

Run the publish job on `ubuntu-latest`. One line (other jobs keep their blacksmith runners — provenance only matters for publish).

## Note

`main` already has a `Bump version to v0.0.7` commit from the failed run (README ecosystem footer landed). The next successful publish will land as `0.0.8`, skipping `0.0.7` on npm — harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)